### PR TITLE
Use GetVehiclePageUseCase for getVehicles call

### DIFF
--- a/app/src/main/java/com/lmorda/homework/domain/usecase/GetVehiclePageUseCase.kt
+++ b/app/src/main/java/com/lmorda/homework/domain/usecase/GetVehiclePageUseCase.kt
@@ -1,0 +1,26 @@
+package com.lmorda.homework.domain.usecase
+
+import com.lmorda.homework.domain.DataRepository
+import com.lmorda.homework.domain.filters.VehicleFilter
+import com.lmorda.homework.domain.filters.VehicleSort
+import com.lmorda.homework.domain.model.Vehicles
+import javax.inject.Inject
+
+class GetVehiclePageUseCase @Inject constructor(
+    private val dataRepository: DataRepository,
+) {
+
+    suspend operator fun invoke(
+        startCursor: String?,
+        sort: VehicleSort,
+        nameLike: String?
+    ): Vehicles {
+        return dataRepository.getVehicles(
+            startCursor = startCursor,
+            sort = sort,
+            filter = nameLike?.takeIf { it.isNotBlank() }?.let {
+                VehicleFilter.NameLike(it)
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/lmorda/homework/ui/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/lmorda/homework/ui/explore/ExploreViewModel.kt
@@ -30,7 +30,6 @@ import kotlin.coroutines.cancellation.CancellationException
 
 @HiltViewModel
 class ExploreViewModel @Inject constructor(
-    private val dataRepository: DataRepository,
     private val featureFlagRepository: FeatureFlagRepository,
     private val getVehiclePageUseCase: GetVehiclePageUseCase,
 ) : MviViewModel<State, Event>(
@@ -124,12 +123,10 @@ class ExploreViewModel @Inject constructor(
                 delay(EXPLORE_FILTER_DEBOUNCE_MILLIS)
             }
             try {
-                val vehiclePage = dataRepository.getVehicles(
+                val vehiclePage = getVehiclePageUseCase.invoke(
                     startCursor = null,
                     sort = VehicleSort.NAME_ASCENDING,
-                    filter = nameLike?.takeIf { it.isNotBlank() }?.let {
-                        VehicleFilter.NameLike(it)
-                    },
+                    nameLike = nameLike,
                 )
                 push(
                     OnLoaded(

--- a/app/src/main/java/com/lmorda/homework/ui/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/lmorda/homework/ui/explore/ExploreViewModel.kt
@@ -8,6 +8,7 @@ import com.lmorda.homework.domain.featureflag.FeatureFlagRepository
 import com.lmorda.homework.domain.filters.VehicleFilter
 import com.lmorda.homework.domain.filters.VehicleSort
 import com.lmorda.homework.domain.model.Vehicle
+import com.lmorda.homework.domain.usecase.GetVehiclePageUseCase
 import com.lmorda.homework.ui.MviViewModel
 import com.lmorda.homework.ui.explore.ExploreContract.Event
 import com.lmorda.homework.ui.explore.ExploreContract.Event.Internal.OnLoadError
@@ -31,6 +32,7 @@ import kotlin.coroutines.cancellation.CancellationException
 class ExploreViewModel @Inject constructor(
     private val dataRepository: DataRepository,
     private val featureFlagRepository: FeatureFlagRepository,
+    private val getVehiclePageUseCase: GetVehiclePageUseCase,
 ) : MviViewModel<State, Event>(
     initialState = State.Initial,
 ) {
@@ -95,12 +97,10 @@ class ExploreViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             try {
-                val vehiclePage = dataRepository.getVehicles(
+                val vehiclePage = getVehiclePageUseCase.invoke(
                     startCursor = nextCursor,
                     sort = VehicleSort.NAME_ASCENDING,
-                    filter = nameLike?.takeIf { it.isNotBlank() }?.let {
-                        VehicleFilter.NameLike(it)
-                    },
+                    nameLike = nameLike,
                 )
                 val vehicles = currentVehicles ?: emptyList()
                 val newVehicles = vehicles + vehiclePage.records

--- a/app/src/test/java/com/lmorda/homework/ExploreViewModelTest.kt
+++ b/app/src/test/java/com/lmorda/homework/ExploreViewModelTest.kt
@@ -4,10 +4,13 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.lmorda.homework.domain.DataRepository
 import com.lmorda.homework.domain.featureflag.FeatureFlag
 import com.lmorda.homework.domain.featureflag.FeatureFlagRepository
+import com.lmorda.homework.domain.filters.VehicleSort
 import com.lmorda.homework.domain.model.mockDomainData
+import com.lmorda.homework.domain.usecase.GetVehiclePageUseCase
 import com.lmorda.homework.ui.explore.ExploreContract
 import com.lmorda.homework.ui.explore.ExploreViewModel
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +38,8 @@ class ExploreViewModelTest {
     private val dataRepository: DataRepository = mockk()
 
     private val featureFlagRepository: FeatureFlagRepository = mockk()
+
+    private val getVehiclePageUseCase: GetVehiclePageUseCase = mockk()
 
     private lateinit var viewModel: ExploreViewModel
 
@@ -65,6 +70,7 @@ class ExploreViewModelTest {
         viewModel = ExploreViewModel(
             dataRepository = dataRepository,
             featureFlagRepository = featureFlagRepository,
+            getVehiclePageUseCase = getVehiclePageUseCase,
         )
 
         assertEquals(ExploreContract.State.Initial, viewModel.state.value)
@@ -74,5 +80,8 @@ class ExploreViewModelTest {
         assertEquals(viewModel.showContacts.first(), true)
     }
 
-    // TODO: Add more unit tests
+    @Test
+    fun `get vehicle page use case called state on next page`() = runTest {
+        // TODO: Add unit test to verify use case is getting called correctly
+    }
 }

--- a/app/src/test/java/com/lmorda/homework/GetVehiclePageUseCaseTest.kt
+++ b/app/src/test/java/com/lmorda/homework/GetVehiclePageUseCaseTest.kt
@@ -1,0 +1,82 @@
+package com.lmorda.homework
+
+import com.lmorda.homework.domain.DataRepository
+import com.lmorda.homework.domain.filters.VehicleFilter
+import com.lmorda.homework.domain.filters.VehicleSort
+import com.lmorda.homework.domain.model.Vehicles
+import com.lmorda.homework.domain.usecase.GetVehiclePageUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class GetVehiclePageUseCaseTest {
+
+    @Test
+    fun `GIVEN no filter for vehicle name WHEN get vehicle page THEN query repository with null filter`() = runTest {
+        val repository = mockk<DataRepository>()
+        val expected = mockk<Vehicles>(relaxed = true)
+
+        // GIVEN repository makes successful API call
+        coEvery {
+            repository.getVehicles(
+                startCursor = "startCursor",
+                sort = VehicleSort.NAME_ASCENDING,
+                filter = null
+            )
+        } returns expected
+
+        // WHEN use case is invoked with null vehicle name
+        val getVehiclePageUseCase = GetVehiclePageUseCase(repository)
+        val vehiclePage = getVehiclePageUseCase(
+            startCursor = "startCursor",
+            sort = VehicleSort.NAME_ASCENDING,
+            nameLike = null
+        )
+
+        // THEN use case returns a page of vehicles without being filtered
+        assertEquals(expected, vehiclePage)
+        coVerify(exactly = 1) {
+            repository.getVehicles(
+                startCursor = "startCursor",
+                sort = VehicleSort.NAME_ASCENDING,
+                filter = null
+            )
+        }
+    }
+
+    @Test
+    fun `GIVEN filter by vehicle name WHEN get vehicle page THEN query repository with NameLike filter`() = runTest {
+        val repository = mockk<DataRepository>()
+        val expected = mockk<Vehicles>(relaxed = true)
+
+        // GIVEN repository makes successful API call with NameLike filter
+        coEvery {
+            repository.getVehicles(
+                startCursor = "startCursor",
+                sort = VehicleSort.NAME_ASCENDING,
+                filter = VehicleFilter.NameLike("Vehicle-001")
+            )
+        } returns expected
+
+        // WHEN use case is invoked with a vehicle name
+        val getVehiclePageUseCase = GetVehiclePageUseCase(repository)
+        val vehiclePage = getVehiclePageUseCase(
+            startCursor = "startCursor",
+            sort = VehicleSort.NAME_ASCENDING,
+            nameLike = "Vehicle-001"
+        )
+
+        // THEN use case returns a page of vehicles filtered by name
+        assertEquals(expected, vehiclePage)
+        coVerify(exactly = 1) {
+            repository.getVehicles(
+                startCursor = "startCursor",
+                sort = VehicleSort.NAME_ASCENDING,
+                filter = VehicleFilter.NameLike("Vehicle-001")
+            )
+        }
+    }
+}


### PR DESCRIPTION
📄 Summary

This PR makes a minor refactor to the homework sample project to improve consistency and readability:

♻️ Replaced the direct dataRepository.getVehicles call with the GetVehiclePageUseCase.
🧹 Simplified the filter logic by passing nameLike directly into the use case.
🔒 Ensures better separation of concerns while maintaining clean architecture principles.
✅ No functional changes — the behavior remains exactly the same.

🛠️ Why

Demonstrates best practices for clean architecture and use case-driven design.
Makes the codebase more maintainable and easier to understand for developers reviewing the sample project.
Keeps the ViewModel lean by delegating data-fetching logic to the use case layer.

📌 Notes

This is part of an ongoing effort to keep the sample project idiomatic and clean, serving as a reference for other developers learning best practices.